### PR TITLE
Provide CSRF token in response headers (fixes #16)

### DIFF
--- a/pyramid_persona/tests.py
+++ b/pyramid_persona/tests.py
@@ -25,6 +25,7 @@ class ViewTests(unittest.TestCase):
         assertion = data['assertion']
 
         request = testing.DummyRequest()
+        request.method = 'POST'
         request.params['assertion'] = assertion
         request.params['csrf_token'] = request.session.get_csrf_token()
         request.params['came_from'] = '/'
@@ -40,6 +41,7 @@ class ViewTests(unittest.TestCase):
         assertion = data['assertion']
 
         request = testing.DummyRequest()
+        request.method = 'POST'
         request.params['assertion'] = assertion
         request.params['csrf_token'] = request.session.get_csrf_token()
 
@@ -58,12 +60,25 @@ class ViewTests(unittest.TestCase):
         assertion = data['assertion']
 
         request = testing.DummyRequest()
+        request.method = 'POST'
         request.params['assertion'] = assertion
         request.params['csrf_token'] = request.session.get_csrf_token()
         request.params['came_from'] = '/'
 
         self.assertRaises(HTTPBadRequest, login, request)
         self.assertFalse(hasattr(self.security_policy, 'remembered'))
+
+    def test_login_logout_views_provide_csrf_token(self):
+        from .views import login, logout
+        request = testing.DummyRequest()
+        login(request)
+        self.assertEqual(request.response.headers['X-Csrf-Token'],
+                         request.session.get_csrf_token())
+
+        request = testing.DummyRequest()
+        logout(request)
+        self.assertEqual(request.response.headers['X-Csrf-Token'],
+                         request.session.get_csrf_token())
 
     def test_logout(self):
         from .views import logout
@@ -107,6 +122,7 @@ class RenderingTests(unittest.TestCase):
         assertion = data['assertion']
 
         request = testing.DummyRequest()
+        request.method = 'POST'
         request.environ['HTTP_HOST'] = 'http://someaudience'
         request.params['assertion'] = assertion
         request.params['csrf_token'] = request.session.get_csrf_token()

--- a/pyramid_persona/views.py
+++ b/pyramid_persona/views.py
@@ -23,15 +23,26 @@ def verify_login(request):
     return data['email']
 
 
+def add_csrf_token(request):
+    """Provides the CSRF token in HTTP headers."""
+    csrf_token = str(request.session.get_csrf_token())
+    request.response.headers['X-Csrf-Token'] = csrf_token
+    return csrf_token
+
+
 def login(request):
     """View to check the persona assertion and remember the user"""
-    email = verify_login(request)
-    request.response.headers.extend(remember(request, email))
-    return {'redirect': request.POST.get('came_from', '/'), 'success': True}
+    add_csrf_token(request)
+    if request.method == 'POST':
+        email = verify_login(request)
+        request.response.headers.extend(remember(request, email))
+        return {'redirect': request.POST.get('came_from', '/'), 'success': True}
+    return {}
 
 
 def logout(request):
     """View to forget the user"""
+    add_csrf_token(request)
     request.response.headers.extend(forget(request))
     return {'redirect': request.POST.get('came_from', '/')}
 


### PR DESCRIPTION
This would allow login in JavaScript, since it allows us to fetch the CRSF token with a `HEAD` on `/login` before posting the full credentials.
