### PR TITLE
Switch to SignedCookieSessionFactory

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -117,7 +117,7 @@ Here is, in details, what including `pyramid_persona` does :
 
 - it defines an authentication policy, an authorization policy, and a session factory     (this is needed for csrf
   protection, and is why we need a secret). Defaults are  `AuthTktAuthenticationPolicy`, `ACLAuthorizationPolicy` and
-  `UnencryptedCookieSessionFactoryConfig`. You can override it if you prefer.
+  `SignedCookieSessionFactory`. You can override it if you prefer.
 - it adds a `persona_js` request attribute containing the javascript code needed to make persona work.
 - it adds a `persona_button` request attribute containing html code for quickly putting a login button.
 - it defines the `/login` and `/logout` views to handle the persona workflow.

--- a/pyramid_persona/__init__.py
+++ b/pyramid_persona/__init__.py
@@ -39,7 +39,7 @@ def includeme(config):
     # Default authentication and authorization policies. Those are needed to remember the userid.
     authz_policy = ACLAuthorizationPolicy()
     config.set_authorization_policy(authz_policy)
-    secret = settings.get('persona.secret', None)
+    secret = settings.get('persona.secret', '')
     authn_policy = AuthTktAuthenticationPolicy(secret, hashalg='sha512')
     config.set_authentication_policy(authn_policy)
 

--- a/pyramid_persona/__init__.py
+++ b/pyramid_persona/__init__.py
@@ -5,7 +5,7 @@ from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import ConfigurationError
 from pyramid.interfaces import ISessionFactory, PHASE2_CONFIG
 from pyramid.security import NO_PERMISSION_REQUIRED
-from pyramid.session import UnencryptedCookieSessionFactoryConfig
+from pyramid.session import SignedCookieSessionFactory
 from pyramid.settings import aslist
 from pyramid_persona.utils import button, js
 from pyramid_persona.views import login, logout, forbidden
@@ -46,7 +46,7 @@ def includeme(config):
     # A default session factory, needed for the csrf check.
 
 
-    session_factory = UnencryptedCookieSessionFactoryConfig(secret)
+    session_factory = SignedCookieSessionFactory(secret)
     config.set_session_factory(session_factory)
 
     # Either a secret must be provided or the session factory must be overriden.


### PR DESCRIPTION
@madjar 
Replace UnencryptedCookieSessionFactoryConfig with SignedCookieSessionFactory, as UnencryptedCookieSessionFactoryConfig is now deprecated in pyramid version 1.5 (see http://docs.pylonsproject.org/projects/pyramid//en/latest/api/session.html#pyramid.session.UnencryptedCookieSessionFactoryConfig).
